### PR TITLE
Update ESLint to 9 and `@opencast/eslint-config-ts-react`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,0 @@
-{
-  "extends": ["@opencast/eslint-config-ts-react"],
-  "ignorePatterns": ["node_modules", "dist"]
-}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,8 @@
+import shared from "@opencast/eslint-config-ts-react";
+
+export default [
+  ...shared,
+  {
+    ignores: ["dist/"],
+  },
+];

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "@opencast/eslint-config-ts-react": "^0.2.0",
+    "@opencast/eslint-config-ts-react": "^0.3.0",
     "@types/react": "^18.2.13",
     "@types/react-dom": "^18.2.19",
+    "eslint": "^9.20.1",
     "typescript": "^5.1.3"
   },
   "peerDependencies": {
@@ -28,6 +29,7 @@
     "@floating-ui/react": "^0.24.3",
     "focus-trap-react": "^10.2.3",
     "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-icons": "^4.9.0",
     "react-merge-refs": "^2.0.2"
   }

--- a/src/button.tsx
+++ b/src/button.tsx
@@ -50,7 +50,7 @@ const css = (
   config: AppkitConfig,
   kind: Kind,
   isHighContrast: boolean,
-  extraCss: Interpolation<Theme> = {}
+  extraCss: Interpolation<Theme> = {},
 ): Interpolation<Theme> => {
   const notDisabledStyle = match(kind, {
     "normal": () => ({

--- a/src/colorScheme.tsx
+++ b/src/colorScheme.tsx
@@ -94,13 +94,6 @@ export const ColorSchemeProvider: React.FC<ColorSchemeProviderProps> = ({
   allowedSchemes = COLOR_SCHEMES,
   children,
 }) => {
-  if (allowedSchemes.length < 2) {
-    return bug("`allowedSchemes` for ColorSchemeProvider need to have at least 2 schemes");
-  }
-  if (!allowedSchemes.includes("light") && !allowedSchemes.includes("dark")) {
-    return bug("`allowedSchemes` must contain either 'light' or 'dark'");
-  }
-
   const isValidScheme = (v: string | undefined | null): v is ColorScheme => {
     return !!v && (allowedSchemes as readonly string[]).includes(v);
   };
@@ -114,6 +107,13 @@ export const ColorSchemeProvider: React.FC<ColorSchemeProviderProps> = ({
   // Next, check whether there are some preferences stored in local storage.
   const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY);
   const [isAuto, setIsAuto] = useState(!isValidScheme(stored));
+
+  if (allowedSchemes.length < 2) {
+    return bug("`allowedSchemes` for ColorSchemeProvider need to have at least 2 schemes");
+  }
+  if (!allowedSchemes.includes("light") && !allowedSchemes.includes("dark")) {
+    return bug("`allowedSchemes` must contain either 'light' or 'dark'");
+  }
 
   const context: ColorSchemeContext = {
     scheme,

--- a/src/floating.tsx
+++ b/src/floating.tsx
@@ -11,6 +11,7 @@ import {
   useClick,
   useDismiss,
   useFloating,
+  UseFloatingReturn,
   useFocus,
   useHover,
   useInteractions,
@@ -45,7 +46,7 @@ type Context = {
             y?: number;
         };
     };
-    refs: Pick<ReturnType<typeof useFloating>["refs"], "setReference" | "setFloating"> & {
+    refs: Pick<UseFloatingReturn["refs"], "setReference" | "setFloating"> & {
         arrowRef: React.MutableRefObject<HTMLDivElement | null>;
         listRef: React.MutableRefObject<Array<HTMLElement | null>>;
     };
@@ -274,6 +275,7 @@ export const FloatingTrigger: React.FC<FloatingTriggerProps> = ({ children }) =>
 
   return React.cloneElement(children, {
     "data-floating-state": context.open ? "open" : "closed",
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     ...context.getReferenceProps({
       ref: context.refs.setReference,
       onClick: () => context.open && context.setOpen?.(false),
@@ -461,7 +463,7 @@ export const WithTooltip = React.forwardRef<FloatingHandle, WithTooltipProps>(
         <FloatingTrigger>{children}</FloatingTrigger>
       </FloatingContainer>
     );
-  }
+  },
 );
 
 

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -133,7 +133,7 @@ export const HeaderMenu: React.FC<HeaderMenuProps> = ({ close, items, label, bre
               if (!keepOpenAfterClick) {
                 close();
               }
-            }} />
+            }} />,
           )}
         </ul>
       </div>

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -41,7 +41,6 @@ export function match<T extends string | number, Out>(
     // understand that in the case of `fallback === undefined`, `arms` is
     // not a partial map. But it is, as you can see from the two callable
     // signatures above.
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     ? arms[value]!()
     : (arms[value] as (() => Out) | undefined ?? fallback)();
 }


### PR DESCRIPTION
This upgrades to the new "flat" config format. It also upgrades `@opencast/eslint-config-ts-react`. All this change enabled new lints, and thus warnings for the given code. These lint warnings were all fixed.